### PR TITLE
Add skip when path to other file provided

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,7 +54,7 @@ jobs:
         id: min_dep_gen_3
         uses: ./
         with:
-          requirements_paths: 'test-requirements.txt other-requirements.txt'
+          requirements_paths: 'requirements.txt other-requirements.txt'
       - name: Verify output
         run: |
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "packaging==20.9"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -60,3 +60,8 @@ jobs:
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "packaging==20.9"
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "requests==2.25.1"
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "-r"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v ".txt"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "core-requirements.txt"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "-r core-requirements.txt"
+

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "packaging==20.9"
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "requests==2.25.1"
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
-      - name: Run Minimum Dependency Generator with 2 files
+      - name: Run Minimum Dependency Generator with 2 files, no other path reference
         id: min_dep_gen_2
         uses: ./
         with:
@@ -48,3 +48,15 @@ jobs:
           echo "${{ steps.min_dep_gen_2.outputs.min_reqs }}" | grep -c "pytest==6.2.4"
           echo "${{ steps.min_dep_gen_2.outputs.min_reqs }}" | grep -c "isort==5.8.0"
           echo "${{ steps.min_dep_gen_2.outputs.min_reqs }}" | grep -c "pytest-cov==2.11.1"
+      - name: Create other requirements file
+        run: printf "-r core-requirements.txt" >> other-requirements.txt
+      - name: Run Minimum Dependency Generator with 2 files, path reference
+        id: min_dep_gen_2
+        uses: ./
+        with:
+          requirements_paths: 'test-requirements.txt other-requirements.txt'
+      - name: Verify output
+        run: |
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "packaging==20.9"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "requests==2.25.1"
+          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "wheel==0.36.2"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
           echo "${{ steps.min_dep_gen_2.outputs.min_reqs }}" | grep -c "isort==5.8.0"
           echo "${{ steps.min_dep_gen_2.outputs.min_reqs }}" | grep -c "pytest-cov==2.11.1"
       - name: Create other requirements file
-        run: printf "-r core-requirements.txt" >> other-requirements.txt
+        run: echo -e "-r core-requirements.txt \nnumpy>=1.13.1" > other-requirements.txt
       - name: Run Minimum Dependency Generator with 2 files, path reference
         id: min_dep_gen_3
         uses: ./
@@ -60,6 +60,7 @@ jobs:
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "packaging==20.9"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "requests==2.25.1"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "numpy==1.13.1"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "-r"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v ".txt"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "core-requirements.txt"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -51,17 +51,17 @@ jobs:
       - name: Create other requirements file
         run: printf "-r core-requirements.txt" >> other-requirements.txt
       - name: Run Minimum Dependency Generator with 2 files, path reference
-        id: min_dep_gen_2
+        id: min_dep_gen_3
         uses: ./
         with:
           requirements_paths: 'test-requirements.txt other-requirements.txt'
       - name: Verify output
         run: |
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "packaging==20.9"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "requests==2.25.1"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "-r"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v ".txt"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "core-requirements.txt"
-          echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -v "-r core-requirements.txt"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "packaging==20.9"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "requests==2.25.1"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "-r"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v ".txt"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "core-requirements.txt"
+          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "-r core-requirements.txt"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           requirements_paths: 'requirements.txt'
       - name: Save the output minimum test requirements
-        run: printf "${{ steps.min_dep_gen_1.outputs.min_reqs }}" >> generated-min--test-reqs.txt
+        run: printf "${{ steps.min_dep_gen_1.outputs.min_reqs }}" >> generated-min-test-reqs.txt
       - name: Verify output
         run: |
           echo "${{ steps.min_dep_gen_1.outputs.min_reqs }}" | grep -c "packaging==20.9"
@@ -55,14 +55,12 @@ jobs:
         uses: ./
         with:
           requirements_paths: 'requirements.txt other-requirements.txt'
+      - name: Save the output minimum test and core requirements
+        run: printf "${{ steps.min_dep_gen_3.outputs.min_reqs }}" >> generated-min-other-reqs.txt
       - name: Verify output
         run: |
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "packaging==20.9"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "requests==2.25.1"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "wheel==0.36.2"
           echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -c "numpy==1.13.1"
-          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "-r"
-          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v ".txt"
-          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "core-requirements.txt"
-          echo "${{ steps.min_dep_gen_3.outputs.min_reqs }}" | grep -v "-r core-requirements.txt"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+other-requirements.txt
+
 docs/source/generated/
 *.dirlock
 *.~lock*

--- a/minimum_dependency_generator/minimum_dependency_generator.py
+++ b/minimum_dependency_generator/minimum_dependency_generator.py
@@ -55,7 +55,7 @@ def find_min_requirement(requirement, python_version="3.7", major_python_version
         return
     requirement = remove_comment(requirement)
     if not verify_python_environment(requirement):
-        return 
+        return
     if ">=" in requirement:
         # mininum version specified (ex - 'package >= 0.0.4')
         package = Requirement(requirement)

--- a/minimum_dependency_generator/minimum_dependency_generator.py
+++ b/minimum_dependency_generator/minimum_dependency_generator.py
@@ -52,10 +52,10 @@ def find_min_requirement(requirement, python_version="3.7", major_python_version
     if is_requirement_path(requirement):
         # skip requirement paths
         # ex '-r core_requirements.txt'
-        return None
+        return
     requirement = remove_comment(requirement)
     if not verify_python_environment(requirement):
-        return None
+        return 
     if ">=" in requirement:
         # mininum version specified (ex - 'package >= 0.0.4')
         package = Requirement(requirement)

--- a/minimum_dependency_generator/minimum_dependency_generator.py
+++ b/minimum_dependency_generator/minimum_dependency_generator.py
@@ -25,6 +25,11 @@ def remove_comment(requirement):
         requirement = requirement.split("#")[0]
     return requirement
 
+def is_requirement_path(requirement):
+    if '.txt' in requirement and '-r' in requirement:
+        return True
+    return False
+
 
 def find_operator_version(package, operator):
     version = None
@@ -43,6 +48,10 @@ def determine_package_name(package):
 
 
 def find_min_requirement(requirement, python_version="3.7", major_python_version="py3"):
+    if is_requirement_path(requirement):
+        # skip requirement paths
+        # ex '-r core_requirements.txt'
+        return None
     requirement = remove_comment(requirement)
     if not verify_python_environment(requirement):
         return None
@@ -79,6 +88,10 @@ def generate_min_requirements(requirements_paths):
         with open(path) as f:
             requirements.extend(f.readlines())
         for req in requirements:
+            if is_requirement_path(req):
+                # skip requirement paths
+                # ex '-r core_requirements.txt'
+                continue
             package = Requirement(remove_comment(req))
             name = determine_package_name(package)
             if name in requirements_to_specifier:

--- a/minimum_dependency_generator/minimum_dependency_generator.py
+++ b/minimum_dependency_generator/minimum_dependency_generator.py
@@ -25,6 +25,7 @@ def remove_comment(requirement):
         requirement = requirement.split("#")[0]
     return requirement
 
+
 def is_requirement_path(requirement):
     if '.txt' in requirement and '-r' in requirement:
         return True

--- a/minimum_dependency_generator/tests/test_minimum_dependency_generator.py
+++ b/minimum_dependency_generator/tests/test_minimum_dependency_generator.py
@@ -76,10 +76,10 @@ def test_upper_bound():
     with pytest.raises(ValueError, match=error_text):
         find_min_requirement("colorama")
 
+
 def test_other_requirement(other_req_path):
     mininum_package = find_min_requirement(other_req_path)
     assert mininum_package is None
-
 
 
 def test_bound(woodwork_dep):

--- a/other-requirements.txt
+++ b/other-requirements.txt
@@ -1,2 +1,0 @@
--r core-requirements.txt 
-numpy>=1.13.1

--- a/other-requirements.txt
+++ b/other-requirements.txt
@@ -1,0 +1,2 @@
+-r core-requirements.txt 
+numpy>=1.13.1


### PR DESCRIPTION
- When a requirement is listed as `-r core-requirements.txt`, this should be skipped.